### PR TITLE
Fixed issue that allows a non-authenticated user to attempt to create…

### DIFF
--- a/src/Controllers/ThreadsController.php
+++ b/src/Controllers/ThreadsController.php
@@ -50,6 +50,9 @@ class ThreadsController extends Controller
 
     public function postCreate(Request $request)
     {
+        if (Gate::denies('create')) {
+            abort(403);
+        }
         $categoryObject = new Category();
 
         $validator = Validator::make($request->all(), [

--- a/src/Policies/ThreadPolicy.php
+++ b/src/Policies/ThreadPolicy.php
@@ -37,6 +37,11 @@ class ThreadPolicy
         ;
     }
 
+    public function create(Model $user)
+    {
+        return $user !== null;
+    }
+    
     public function edit(Model $user, Thread $thread)
     {
         if (UserHelper::isModerator($user, $thread->category)) {

--- a/src/resources/views/categories/view.blade.php
+++ b/src/resources/views/categories/view.blade.php
@@ -2,7 +2,7 @@
 
 @section('liddleforum_content_inner')
 
-	@if($category->parent_id)
+	@if($category->parent_id && Auth::user() !== null)
 		<a href="{{ route('liddleforum.threads.create', ['category' => $category->slug]) }}" class="btn btn-primary btn-sm pull-right">Create Thread</a>
 	@endif
 	<p class="thread-title">


### PR DESCRIPTION
The ThreadsController wasn't checking that a user is authenticated before creating a new thread. The Create Thread button still showed up and the application will crash.